### PR TITLE
add support for generating output tree for module from output.tf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+PYTHON := $(shell command -v python || command -v python3 || echo "")
+
+ifeq ($(PYTHON),)
+  $(error "Python is not installed. Please install Python 3.")
+endif
+
+.PHONY: init install test
+
+init:
+	$(PYTHON) -m venv env
+	source "./env/bin/activate"
+	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+	source "$(HOME)/.cargo/env"
+
+install: init
+	pip install .
+
+test: init
+	pip install pytest
+	pytest tests

--- a/ftf_cli/utils.py
+++ b/ftf_cli/utils.py
@@ -29,6 +29,27 @@ def validate_facets_yaml(path):
 
     return yaml_path
 
+def generate_output_tree(obj):
+    """ Generate a JSON schema from a output.tf file. """
+    if isinstance(obj, dict):
+        transformed = {}
+        for key, value in obj.items():
+            transformed[key] = generate_output_tree(value)
+        return transformed
+    elif isinstance(obj, list):
+        if len(obj) > 0:
+            return {"type": "array", "items": generate_output_tree(obj[0])}
+        else:
+            return {"type": "array"}  # No "items" if unknown
+    elif isinstance(obj, bool):
+        return {"type": "boolean"}
+    elif isinstance(obj, (int, float)):
+        return {"type": "number"}
+    elif isinstance(obj, str):
+        return {"type": "string"}
+    else:
+        return {"type": "any"}  # Catch unexpected types
+
 
 def load_facets_yaml(path):
     """Load and validate facets.yaml file, returning its content as an object."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,58 @@
+import pytest
+from ftf_cli.utils import generate_output_tree
+
+def test_dict_input():
+    """Test with a dictionary input."""
+    input_data = {
+        "key1": "value1",
+        "key2": 123,
+        "key3": {
+            "nested_key1": True,
+            "nested_key2": [1, 2, 3]
+        }
+    }
+    expected_output = {
+        "key1": {"type": "string"},
+        "key2": {"type": "number"},
+        "key3": {
+            "nested_key1": {"type": "boolean"},
+            "nested_key2": {"type": "array", "items": {"type": "number"}}
+        }
+    }
+    assert generate_output_tree(input_data) == expected_output
+
+def test_list_input():
+    """Test with a list input."""
+    input_data = [1, 2, 3]
+    expected_output = {"type": "array", "items": {"type": "number"}}
+    assert generate_output_tree(input_data) == expected_output
+
+def test_empty_list():
+    """Test with an empty list."""
+    input_data = []
+    expected_output = {"type": "array"}
+    assert generate_output_tree(input_data) == expected_output
+
+def test_boolean_input():
+    """Test with a boolean input."""
+    input_data = True
+    expected_output = {"type": "boolean"}
+    assert generate_output_tree(input_data) == expected_output
+
+def test_number_input():
+    """Test with a number input."""
+    input_data = 42
+    expected_output = {"type": "number"}
+    assert generate_output_tree(input_data) == expected_output
+
+def test_string_input():
+    """Test with a string input."""
+    input_data = "hello"
+    expected_output = {"type": "string"}
+    assert generate_output_tree(input_data) == expected_output
+
+def test_unexpected_type():
+    """Test with an unexpected type."""
+    input_data = object()
+    expected_output = {"type": "any"}
+    assert generate_output_tree(input_data) == expected_output


### PR DESCRIPTION
This pr adds the support for generating output tree before registering the module.

Sample Output:
<img width="1440" alt="Screenshot 2025-03-20 at 1 25 12 PM" src="https://github.com/user-attachments/assets/5029409a-68e5-40f4-b00a-fd0d3fe65ebe" />

Executing register with preview:
<img width="1440" alt="Screenshot 2025-03-20 at 1 27 15 PM" src="https://github.com/user-attachments/assets/aa2d4664-7106-447f-8209-2bd0e43ea6d5" />

Generated Output Tree:
<img width="1440" alt="Screenshot 2025-03-20 at 1 26 03 PM" src="https://github.com/user-attachments/assets/87aba898-25d6-4d2f-a259-5e044543940e" />

Sample Resource Creation in BP with New Module:
<img width="1398" alt="Screenshot 2025-03-20 at 1 33 05 PM" src="https://github.com/user-attachments/assets/fcde2229-7862-49bb-9aa7-232f96bfc7c2" />

Referencing the Outputs:
<img width="1440" alt="Screenshot 2025-03-20 at 1 30 46 PM" src="https://github.com/user-attachments/assets/afc69735-5d16-4ec2-8c62-7ee5e6e49bfe" />

