### PR TITLE
add support to expose provider in output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,20 @@ ifeq ($(PYTHON),)
   $(error "Python is not installed. Please install Python 3.")
 endif
 
-.PHONY: init install test
+.PHONY: setup install test
 
-init:
+setup:
 	$(PYTHON) -m venv env
 	source "./env/bin/activate"
 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 	source "$(HOME)/.cargo/env"
+	$(PYTHON) -m pip install -r requirements.txt
 
-install: init
+install: setup
 	pip install .
 
-test: init
+test: setup
 	pip install pytest
 	pytest tests
+
+all: setup test install

--- a/README.md
+++ b/README.md
@@ -158,6 +158,27 @@ You can even set env vars GIT_REPO_URL, GIT_REF, FACETS_PROFILE. Particularly us
 - The version will be changed to a local testing version such as 1.0-username
 
 
+#### Expose Provider
+
+Expose a new provider in the module output by specifying necessary details.
+
+```bash
+ftf expose-provider [OPTIONS] /path/to/module
+```
+
+Prompts for Provider Name, Source, Version, Attributes and Output.
+
+**Options**:
+- `-n, --name`: (prompt) Provider Name.
+- `-s, --source`: (prompt) Provider Source.
+- `-v, --version`: (prompt) Provider Version.
+- `-a, --attributes`: (prompt) Provider Attributes comma-separated list of  of map items; attributes mapped to their values with equal(=) symbol. eg : "attribute1=val1,depth.attribute2=val2" format.
+- `-o, --output`: (prompt) Output to expose provider as a part of. 
+
+**Notes**:
+- Supports nested attributes using dot notation in attribute name.
+- By default, a default output will be created if none is present of type intent provided in facets.yaml with name "default".
+
 ## Contribution
 
 Feel free to fork the repository and submit pull requests for any feature enhancements or bug fixes.

--- a/ftf_cli/cli.py
+++ b/ftf_cli/cli.py
@@ -4,6 +4,7 @@ from ftf_cli.commands.add_variable import add_variable
 from ftf_cli.commands.login import login
 from ftf_cli.commands.validate_directory import validate_directory
 from ftf_cli.commands.preview_module import preview_module
+from ftf_cli.commands.expose_provider import expose_provider
 
 
 @click.group()
@@ -17,3 +18,4 @@ cli.add_command(add_variable)
 cli.add_command(validate_directory)
 cli.add_command(login)
 cli.add_command(preview_module)
+cli.add_command(expose_provider)

--- a/ftf_cli/commands/expose_provider.py
+++ b/ftf_cli/commands/expose_provider.py
@@ -1,0 +1,250 @@
+import click
+import yaml
+import os
+import questionary
+import hcl2
+from ftf_cli.utils import generate_output_tree
+
+
+@click.command()
+@click.argument("path", type=click.Path(exists=True))
+@click.option(
+    "-n",
+    "--name",
+    prompt="Enter the name of the provider",
+    help="The name of the provider.",
+)
+@click.option(
+    "-s",
+    "--source",
+    prompt="Enter the source of the provider",
+    help="The source of the provider.",
+)
+@click.option(
+    "-v",
+    "--version",
+    prompt="Enter the version of the provider",
+    help="The version of the provider.",
+)
+@click.option(
+    "-a",
+    "--attributes",
+    prompt="Enter the comma seperated list of map items; attributes mapped to their values with equal(=) symbol (dot-separated keys for nested)",
+    help='Comma seperated list of  of map items; attributes mapped to their values with equal(=) symbol. eg : "attribute1=val1,depth.attribute2=val2" format. Supports nested attributes with "." character.',
+)
+@click.option(
+    "-o",
+    "--output",
+    default=None,
+    help='Output to expose provider as a part of. By default, a default output will be created if none is present of type intent provided in facets.yaml with name "default".',
+)
+def expose_provider(path, name, source, version, attributes, output):
+    """Exposes the provider in facets yaml"""
+    pairs = attributes.split(",")
+    prosssed_attributes = {}
+    for pair in pairs:
+        if "=" not in pair:
+            # Assign None if no value is provided
+            prosssed_attributes[pair.strip()] = None
+        else:
+            key, value = pair.split("=", 1)
+            prosssed_attributes[key.strip()] = value.strip()
+    providers = {}
+    providers[name] = {
+        "source": source,
+        "version": version,
+        "attributes": prosssed_attributes,
+    }
+
+    try:
+        facets_yaml_path = os.path.join(path, "facets.yaml")
+        output_file = os.path.join(path, "output.tf")
+
+        if not (os.path.exists(output_file) and os.path.exists(facets_yaml_path)):
+            click.echo(
+                f"❌ {output_file} or {facets_yaml_path} not found. Run validate directory command to validate directory"
+            )
+            return
+
+        with open(facets_yaml_path, "r") as file:
+            facets_yaml = yaml.safe_load(file)
+            file.close()
+
+        # Get outputs declared in facets yaml
+        outputs = facets_yaml.get("outputs")
+        output_list = []
+        if outputs != None:
+            output_list = outputs.keys()
+
+        # Mention there are no outputs and generate the default output with intent name
+        if len(output_list) < 1:
+
+            click.echo(f"⚠️ No output found in {facets_yaml_path}.")
+            intent = facets_yaml.get("intent", "")
+
+            if intent == "":
+                click.echo(
+                    f"❌ Invalid facets yaml {facets_yaml_path}. Run validate directory command to validate."
+                )
+                return
+
+            output_type = f"@outputs/{intent}"
+
+            click.echo(f"🔧 Generating default output of type {output_type}.")
+
+            new_output = generate_default_output(output_type)
+            # add the default output generated to in memory yaml
+            facets_yaml.update(new_output)
+
+            output_list.append("default")
+
+        if not output:
+            output = questionary.select(
+                "Select output where you want to expose provider as a part of:",
+                choices=output_list,
+            ).ask()
+        elif output not in output_list:
+            click.echo(f"❌ Invalid output {output}. Please select from {output_list}")
+            return
+
+        # generate output selection menu
+        output_lookup = generate_output_lookup(path)
+
+        provider_attributes = providers[name]["attributes"]
+
+        # prompt for output selection for attributes
+        for attribute in provider_attributes.keys():
+            if provider_attributes[attribute] == None:
+                referred_output = prompt_user_for_output_selection(
+                    output_lookup, attribute, True
+                )
+                provider_attributes[attribute] = referred_output
+                click.echo(f"Attribute {attribute} will be read from {referred_output}")
+            else:
+                click.echo(
+                    f"Attribute {attribute} will be read from {provider_attributes[attribute]}"
+                )
+
+        # convert output_attributes to attributes and output_interfaces to interfaces
+        for key, value in provider_attributes.items():
+            if isinstance(value, str) and value.startswith("output_attributes"):
+                provider_attributes[key] = value.replace(
+                    "output_attributes", "attributes"
+                )
+            elif isinstance(value, str) and value.startswith("output_interfaces"):
+                provider_attributes[key] = value.replace(
+                    "output_interfaces", "interfaces"
+                )
+
+        # deflatten the attributes
+        provider_attributes = deflatten_dict(provider_attributes)
+
+        # update the deflatten attributes
+        providers[name]["attributes"] = provider_attributes
+
+        # add empty providers map if providers does not exist in selected output
+        if not "providers" in facets_yaml["outputs"][output]:
+            facets_yaml["outputs"][output]["providers"] = {}
+
+        # add the generated provider config to selected output
+        facets_yaml["outputs"][output]["providers"].update(providers)
+
+        with open(facets_yaml_path, "w") as file:
+            yaml.dump(facets_yaml, file, default_flow_style=False)
+            file.close()
+
+        click.echo(f"✅ Sucessfully exposed the provider {name} in output {output}")
+
+    except Exception as e:
+        click.echo(f"❌ Error encounter while adding provider {name}: {e}")
+
+
+def generate_default_output(output_type):
+    """Generate default output if none is present."""
+    output = {"outputs": {"default": {"type": output_type}}}
+    return output
+
+
+def prompt_user_for_output_selection(obj, attribute, is_root=False):
+    """Function to keep prompting the user to select fields from output lookup"""
+    keys = list(obj.keys())
+    if not is_root:
+        keys.append("*")
+    selected_output = questionary.select(
+        f"Keep selecting the field to read attribute {attribute} from:",
+        choices=keys,
+    ).ask()
+
+    # select whole object as output
+    if selected_output == "*":
+        return ""
+
+    nested_obj = obj[selected_output]
+
+    # if selected object is empty object
+    if nested_obj == {}:
+        raise Exception(
+            f"❌ Selected object {selected_output} does not expose any fields."
+        )
+
+    # if selected object is terminating node
+    if "type" in nested_obj:
+        return selected_output
+
+    # keep promting further
+    result = prompt_user_for_output_selection(nested_obj, attribute)
+
+    # generate the path
+    if result == "" or result == "*":
+        return selected_output
+    else:
+        return selected_output + "." + result
+
+
+def generate_output_lookup(path):
+    """Generate output lookup tree"""
+    output_file = os.path.join(path, "output.tf")
+    if not os.path.exists(output_file):
+        click.echo(
+            f"⚠️: {output_file} not found. Cannot expose providers if outputs are not defined."
+        )
+        return
+
+    with open(output_file, "r") as file:
+        parsed_outputs = hcl2.load(file)
+        file.close()
+
+    locals = parsed_outputs.get("locals", [{}])[0]
+    output_interfaces = locals.get("output_interfaces", [{}])[0]
+    output_attributes = locals.get("output_attributes", [{}])[0]
+    output_blocks = parsed_outputs.get("output", [])
+
+    output = {
+        "output_attributes": output_attributes,
+        "output_interfaces": output_interfaces,
+    }
+
+    output_tree = generate_output_tree(output)
+
+    for output_block in output_blocks:
+        for key, _ in output_block.items():
+            output_tree[key] = {"type": "any"}
+
+    return output_tree
+
+
+def deflatten_dict(dict):
+    """Deflatten the dictionary"""
+
+    deflatten_dict = {}
+    for key, value in dict.items():
+        front = deflatten_dict
+        back = front
+        paths = list(key.split("."))
+        for path in paths:
+            if front.get(path) == None:
+                front[path] = {}
+            back = front
+            front = front[path]
+        back[path] = value
+    return deflatten_dict

--- a/ftf_cli/test/test_expose_provider.py
+++ b/ftf_cli/test/test_expose_provider.py
@@ -1,0 +1,57 @@
+import os
+import pytest
+import yaml
+from unittest.mock import patch, mock_open
+from ftf_cli.commands.expose_provider import expose_provider, generate_output_lookup, deflatten_dict
+
+@pytest.fixture
+def mock_facets_yaml():
+    return {
+        "intent": "example-intent",
+        "outputs": {
+            "default": {
+                "type": "@outputs/example-intent",
+                "providers": {}
+            }
+        }
+    }
+
+@pytest.fixture
+def mock_output_tf():
+    return """
+    output "example_output" {
+        value = "${aws_s3_bucket.example_bucket}"
+    }
+    """
+
+def test_generate_output_lookup(mocker, mock_output_tf):
+    # Mock file operations
+    mock_open_file = mocker.patch("builtins.open", mock_open(read_data=mock_output_tf))
+    mocker.patch("os.path.exists", return_value=True)
+
+    # Run the function
+    output_tree = generate_output_lookup("mocked_path")
+
+    # Assert output tree structure
+    assert "example_output" in output_tree
+    assert output_tree["example_output"]["type"] == "any"
+
+def test_deflatten_dict():
+    # Input flattened dictionary
+    flattened_dict = {
+        "key1": "value1",
+        "key2.subkey1": "value2",
+        "key2.subkey2": "value3"
+    }
+
+    # Run the function
+    result = deflatten_dict(flattened_dict)
+
+    # Assert deflattened structure
+    assert result == {
+        "key1": "value1",
+        "key2": {
+            "subkey1": "value2",
+            "subkey2": "value3"
+        }
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ PyYAML
 python-hcl2
 jsonschema
 requests
+checkov
+questionary
+pytest-mock

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
         'checkov',
         'jsonschema',
         'requests',
-        'python-hcl2'
+        'python-hcl2',
+        'questionary'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
This pr adds functionality to expose provider in outputs in facets.yaml. Adds command `expose-provider` to cli.

> [!NOTE]  
> - If the provider already exists with the same name, the new config will override the previous config.
> - If there are no outputs defined the command will create a default output of type intent mentioned in facets.yaml. Will exit out if intent is not found with message to run validate command.

https://drive.google.com/file/d/1K1b3c4FneRlNpllV52JOlM2x0GUj3FbC/view?usp=drive_link