### PR TITLE
allow array in facets.yaml if x-ui-override-disable flag is set to true

### DIFF
--- a/ftf_cli/utils.py
+++ b/ftf_cli/utils.py
@@ -266,10 +266,11 @@ def check_no_array_or_invalid_pattern_in_spec(spec_obj, path="spec"):
     for key, value in spec_obj.items():
         if isinstance(value, dict):
             field_type = value.get("type")
-            if field_type == "array":
+            override_flag = value.get("x-ui-override-disable", False)
+            if field_type == "array" and not override_flag:
                 raise click.UsageError(
                     f"Invalid array type found at {path}.{key}. "
-                    f"Arrays are not allowed in spec. Use patternProperties for array-like structures instead."
+                    f"Arrays without x-ui-override-disable field are not allowed in spec. Use patternProperties for array-like structures instead or set x-ui-override-disable field to true."
                 )
             if "patternProperties" in value:
                 pp = value["patternProperties"]


### PR DESCRIPTION
Allow arrays in facets.yaml with `x-ui-overrride` field set to true.


https://github.com/user-attachments/assets/43548615-7b1c-4273-843b-9309fe1650e4

