### PR TITLE
Handling some edge cases in facets.yaml validations

### DIFF
--- a/ftf_cli/schema.py
+++ b/ftf_cli/schema.py
@@ -107,11 +107,8 @@ spec_schema = {
         "x-ui-variable-ref": {"type": "boolean"},
         "x-ui-secret-ref": {"type": "boolean"},
         "x-ui-dynamic-enum": {
-            "type": "object",
-            "properties": {
-                "sourceField": {"type": "string"},
-            },
-            "required": ["sourceField"],
+            "type": "string",
+            "pattern": "^([a-zA-Z0-9_-]+|\\*)(\\.([a-zA-Z0-9_-]+|\\*))*$"
         },
         "x-ui-overrides-only": {"type": "boolean"},
         "x-ui-override-disable": {"type": "boolean"},

--- a/ftf_cli/utils.py
+++ b/ftf_cli/utils.py
@@ -287,7 +287,7 @@ def check_no_array_or_invalid_pattern_in_spec(spec_obj, path="spec"):
             if field_type == "array" and not override_disable_flag and not overrides_only_flag:
                 raise click.UsageError(
                     f"Invalid array type found at {path}.{key}. "
-                    f"Arrays without x-ui-override-disable or x-ui-overrides-only field are not allowed in spec. Use patternProperties for array-like structures instead or set x-ui-override-disable field to true."
+                    f"Arrays without x-ui-override-disable or x-ui-overrides-only field are not allowed in spec. Use patternProperties for array-like structures instead or set either x-ui-override-disable or x-ui-overrides-only field to true."
                 )
             if "patternProperties" in value:
                 pp = value["patternProperties"]

--- a/tests/test_utils_validation.py
+++ b/tests/test_utils_validation.py
@@ -17,7 +17,7 @@ def test_array_type_raises():
 
 
 def test_pattern_properties_value_not_dict_raises():
-    spec = {"some_field": {"patternProperties": {"^pattern$": {"type": "string"}}}}
+    spec = {"some_field": {"patternProperties": {"^pattern$": {"type": "array"}}}}
     with pytest.raises(click.UsageError) as excinfo:
         check_no_array_or_invalid_pattern_in_spec(spec)
     assert (

--- a/tests/test_utils_validation.py
+++ b/tests/test_utils_validation.py
@@ -21,7 +21,7 @@ def test_pattern_properties_value_not_dict_raises():
     with pytest.raises(click.UsageError) as excinfo:
         check_no_array_or_invalid_pattern_in_spec(spec)
     assert (
-        'patternProperties at spec.some_field with pattern "^pattern$" must be of type object.'
+        'patternProperties at spec.some_field with pattern "^pattern$" must be of type object or string'
         in str(excinfo.value)
     )
 


### PR DESCRIPTION
- `patternProperties` supported with type `string`, but needs to have `x-ui-yaml-editor`
- fix `x-ui-dynamic-enum` schema - its value is a `string`, not `object`
- `x-ui-overrides-only` also allowed in case of `type: array`