### PR TITLE
Add validation for required title and description fields in properties

### DIFF
--- a/ftf_cli/utils.py
+++ b/ftf_cli/utils.py
@@ -268,6 +268,58 @@ def update_spec_variable(
         return
 
 
+def check_properties_have_required_fields(spec_obj, path="spec"):
+    """
+    Recursively check that individual properties within spec.properties have proper title and description fields.
+    This ensures that user-facing properties are properly documented.
+    Raises a UsageError if a property is missing title or description.
+    """
+    if not isinstance(spec_obj, dict):
+        return
+
+    # Check if this is a properties object
+    if "properties" in spec_obj and isinstance(spec_obj["properties"], dict):
+        properties = spec_obj["properties"]
+        for prop_name, prop_def in properties.items():
+            if isinstance(prop_def, dict):
+                # Check if this property has a type (indicating it's a user-facing property)
+                if "type" in prop_def:
+                    # Skip properties that are marked as override-disabled (internal/system properties)
+                    # Properties with x-ui-overrides-only are still user-facing and need validation
+                    override_disable_flag = prop_def.get("x-ui-override-disable", False)
+
+                    if not override_disable_flag:
+                        missing_fields = []
+
+                        # Check if title is missing
+                        if "title" not in prop_def or not prop_def["title"]:
+                            missing_fields.append("title")
+
+                        # Check if description is missing
+                        if "description" not in prop_def or not prop_def["description"]:
+                            missing_fields.append("description")
+
+                        if missing_fields:
+                            if len(missing_fields) == 1:
+                                field_text = f"'{missing_fields[0]}' field"
+                            else:
+                                fields_str = "', '".join(missing_fields)
+                                field_text = f"'{fields_str}' fields"
+
+                            raise click.UsageError(
+                                f"Missing required {field_text} for property '{prop_name}' at {path}.properties.{prop_name}. "
+                                f"All user-facing properties must have both title and description to help users understand their purpose."
+                            )
+
+                # Recursively check nested objects
+                check_properties_have_required_fields(prop_def, path=f"{path}.properties.{prop_name}")
+
+    # Also check nested objects that might have their own properties
+    for key, value in spec_obj.items():
+        if isinstance(value, dict) and key != "properties":
+            check_properties_have_required_fields(value, path=f"{path}.{key}")
+
+
 def check_no_array_or_invalid_pattern_in_spec(spec_obj, path="spec"):
     """
     Recursively check that no field in spec is of type 'array'.
@@ -311,6 +363,8 @@ def validate_yaml(data):
         # Additional check for arrays and invalid patternProperties in spec
         if spec_obj:
             check_no_array_or_invalid_pattern_in_spec(spec_obj)
+            # Check that properties have proper title and description fields
+            check_properties_have_required_fields(spec_obj)
     except jsonschema.exceptions.ValidationError as e:
         raise click.UsageError(
             f"Validation error in `facets.yaml`: `facets.yaml` is not following Facets Schema: {e}"

--- a/tests/test_utils_validation.py
+++ b/tests/test_utils_validation.py
@@ -1,6 +1,6 @@
 import pytest
 import click
-from ftf_cli.utils import check_no_array_or_invalid_pattern_in_spec
+from ftf_cli.utils import check_no_array_or_invalid_pattern_in_spec, check_properties_have_required_fields, validate_yaml
 
 
 def test_no_array_type_pass():
@@ -52,3 +52,335 @@ def test_nested_structure_with_array_type_raises():
     with pytest.raises(click.UsageError) as excinfo:
         check_no_array_or_invalid_pattern_in_spec(spec)
     assert "Invalid array type found at spec.level1.level2.field" in str(excinfo.value)
+
+
+# Tests for property title and description validation
+def test_properties_with_title_and_description_pass():
+    """Test that properties with both title and description pass validation."""
+    spec = {
+        "type": "object",
+        "properties": {
+            "project": {
+                "type": "string",
+                "title": "Project ID",
+                "description": "The project in context to create google cloud resources"
+            },
+            "service_account": {
+                "type": "string",
+                "title": "Service Account",
+                "description": "The service account to impersonate"
+            }
+        }
+    }
+    # Should pass silently
+    check_properties_have_required_fields(spec)
+
+
+def test_property_missing_title_raises():
+    """Test that property missing title raises error."""
+    spec = {
+        "type": "object",
+        "properties": {
+            "project": {
+                "type": "string",
+                "title": "Project ID",
+                "description": "The project in context to create google cloud resources"
+            },
+            "service_account": {
+                "type": "string",
+                "description": "The service account to impersonate"
+                # Missing title
+            }
+        }
+    }
+    with pytest.raises(click.UsageError) as excinfo:
+        check_properties_have_required_fields(spec)
+    assert "Missing required 'title' field for property 'service_account'" in str(excinfo.value)
+    assert "spec.properties.service_account" in str(excinfo.value)
+
+
+def test_property_missing_description_raises():
+    """Test that property missing description raises error."""
+    spec = {
+        "type": "object",
+        "properties": {
+            "project": {
+                "type": "string",
+                "title": "Project ID",
+                "description": "The project in context to create google cloud resources"
+            },
+            "service_account": {
+                "type": "string",
+                "title": "Service Account"
+                # Missing description
+            }
+        }
+    }
+    with pytest.raises(click.UsageError) as excinfo:
+        check_properties_have_required_fields(spec)
+    assert "Missing required 'description' field for property 'service_account'" in str(excinfo.value)
+    assert "spec.properties.service_account" in str(excinfo.value)
+
+
+def test_property_missing_both_title_and_description_raises():
+    """Test that property missing both title and description raises error."""
+    spec = {
+        "type": "object",
+        "properties": {
+            "project": {
+                "type": "string",
+                "title": "Project ID",
+                "description": "The project in context to create google cloud resources"
+            },
+            "service_account": {
+                "type": "string"
+                # Missing both title and description
+            }
+        }
+    }
+    with pytest.raises(click.UsageError) as excinfo:
+        check_properties_have_required_fields(spec)
+    error_message = str(excinfo.value)
+    assert "Missing required 'title', 'description' fields for property 'service_account'" in error_message
+    assert "spec.properties.service_account" in error_message
+
+
+def test_property_empty_fields_raises():
+    """Test that property with empty title and description raises error."""
+    spec = {
+        "type": "object",
+        "properties": {
+            "project": {
+                "type": "string",
+                "title": "",  # Empty title
+                "description": ""  # Empty description
+            }
+        }
+    }
+    with pytest.raises(click.UsageError) as excinfo:
+        check_properties_have_required_fields(spec)
+    error_message = str(excinfo.value)
+    assert "Missing required 'title', 'description' fields for property 'project'" in error_message
+
+
+def test_override_disabled_properties_skip_validation():
+    """Test that properties with x-ui-override-disable skip title and description validation."""
+    spec = {
+        "type": "object",
+        "properties": {
+            "internal_field": {
+                "type": "string",
+                "x-ui-override-disable": True
+                # No title or description required for override-disabled fields
+            },
+            "user_field": {
+                "type": "string",
+                "title": "User Field",
+                "description": "A user-facing field"
+            }
+        }
+    }
+    # Should pass silently
+    check_properties_have_required_fields(spec)
+
+
+def test_overrides_only_properties_require_validation():
+    """Test that properties with x-ui-overrides-only still require title and description validation."""
+    spec = {
+        "type": "object",
+        "properties": {
+            "override_field": {
+                "type": "string",
+                "x-ui-overrides-only": True
+                # Missing title and description - should fail validation
+            },
+            "user_field": {
+                "type": "string",
+                "title": "User Field",
+                "description": "A user-facing field"
+            }
+        }
+    }
+    # Should fail because override_field is missing title and description
+    with pytest.raises(click.UsageError) as excinfo:
+        check_properties_have_required_fields(spec)
+    error_message = str(excinfo.value)
+    assert "Missing required 'title', 'description' fields for property 'override_field'" in error_message
+    assert "spec.properties.override_field" in error_message
+
+
+def test_overrides_only_properties_with_title_and_description_pass():
+    """Test that properties with x-ui-overrides-only pass when they have title and description."""
+    spec = {
+        "type": "object",
+        "properties": {
+            "override_field": {
+                "type": "string",
+                "title": "Override Field",
+                "description": "A field available for overrides",
+                "x-ui-overrides-only": True
+            },
+            "user_field": {
+                "type": "string",
+                "title": "User Field",
+                "description": "A user-facing field"
+            }
+        }
+    }
+    # Should pass silently
+    check_properties_have_required_fields(spec)
+
+
+def test_nested_object_properties_validation():
+    """Test that nested object properties are also validated for title and description."""
+    spec = {
+        "type": "object",
+        "properties": {
+            "database": {
+                "type": "object",
+                "title": "Database Configuration",
+                "description": "Database configuration",
+                "properties": {
+                    "host": {
+                        "type": "string",
+                        "title": "Database Host",
+                        "description": "Database host"
+                    },
+                    "port": {
+                        "type": "number",
+                        "title": "Database Port"
+                        # Missing description - should fail
+                    }
+                }
+            }
+        }
+    }
+    with pytest.raises(click.UsageError) as excinfo:
+        check_properties_have_required_fields(spec)
+    assert "Missing required 'description' field for property 'port'" in str(excinfo.value)
+    assert "spec.properties.database.properties.port" in str(excinfo.value)
+
+
+def test_validate_yaml_with_missing_property_title():
+    """Test that validate_yaml function catches missing property title."""
+    yaml_data = {
+        "intent": "test-intent",
+        "flavor": "test-flavor",
+        "version": "1.0",
+        "description": "Test module description",
+        "clouds": ["aws"],
+        "spec": {
+            "type": "object",
+            "properties": {
+                "project": {
+                    "type": "string",
+                    "title": "Project ID",
+                    "description": "The project in context"
+                },
+                "region": {
+                    "type": "string",
+                    "description": "The region to deploy resources"
+                    # Missing title
+                }
+            }
+        }
+    }
+    with pytest.raises(click.UsageError) as excinfo:
+        validate_yaml(yaml_data)
+    assert "Missing required 'title' field for property 'region'" in str(excinfo.value)
+
+
+def test_validate_yaml_with_missing_property_description():
+    """Test that validate_yaml function catches missing property description."""
+    yaml_data = {
+        "intent": "test-intent",
+        "flavor": "test-flavor",
+        "version": "1.0",
+        "description": "Test module description",
+        "clouds": ["aws"],
+        "spec": {
+            "type": "object",
+            "properties": {
+                "project": {
+                    "type": "string",
+                    "title": "Project ID",
+                    "description": "The project in context"
+                },
+                "region": {
+                    "type": "string",
+                    "title": "Region"
+                    # Missing description
+                }
+            }
+        }
+    }
+    with pytest.raises(click.UsageError) as excinfo:
+        validate_yaml(yaml_data)
+    assert "Missing required 'description' field for property 'region'" in str(excinfo.value)
+
+
+def test_validate_yaml_with_overrides_only_missing_fields():
+    """Test that validate_yaml fails when x-ui-overrides-only properties are missing title/description."""
+    yaml_data = {
+        "intent": "test-intent",
+        "flavor": "test-flavor",
+        "version": "1.0",
+        "description": "Test module description",
+        "clouds": ["aws"],
+        "spec": {
+            "type": "object",
+            "properties": {
+                "project": {
+                    "type": "string",
+                    "title": "Project ID",
+                    "description": "The project in context"
+                },
+                "override_field": {
+                    "type": "string",
+                    "description": "An override field",
+                    "x-ui-overrides-only": True
+                    # Missing title - should fail
+                }
+            }
+        }
+    }
+    with pytest.raises(click.UsageError) as excinfo:
+        validate_yaml(yaml_data)
+    assert "Missing required 'title' field for property 'override_field'" in str(excinfo.value)
+
+
+def test_validate_yaml_with_proper_property_fields_passes():
+    """Test that validate_yaml passes when all properties have title and description."""
+    yaml_data = {
+        "intent": "test-intent",
+        "flavor": "test-flavor",
+        "version": "1.0",
+        "description": "Test module description",
+        "clouds": ["aws"],
+        "spec": {
+            "title": "Test Spec",  # Optional
+            "description": "Test spec description",  # Optional
+            "type": "object",
+            "properties": {
+                "project": {
+                    "type": "string",
+                    "title": "Project ID",
+                    "description": "The project in context to create google cloud resources"
+                },
+                "service_account": {
+                    "type": "string",
+                    "title": "Service Account",
+                    "description": "The service account to impersonate"
+                },
+                "override_field": {
+                    "type": "string",
+                    "title": "Override Field",
+                    "description": "A field available for overrides",
+                    "x-ui-overrides-only": True
+                }
+            }
+        }
+    }
+    # Should pass without raising an exception
+    result = validate_yaml(yaml_data)
+    assert result is True


### PR DESCRIPTION
- Introduced a new function `check_properties_have_required_fields` to ensure that all user-facing properties in the spec have both title and description fields.
- Updated the `validate_yaml` function to include this new validation check.
- Added comprehensive unit tests to cover various scenarios, including missing title, description, and both fields, as well as handling of override-disabled properties.