### PR TITLE
Revert "use git bash for windows as quick fix"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ To install FTF CLI from source, follow these steps:
 
 - Python 3.9 or later
 - Virtual environment (recommended)
-- [jq](https://github.com/jqlang/jq)
-- [Git Bash](https://winget.run/pkg/Git/Git) 
 
 #### Steps
 


### PR DESCRIPTION
Reverts Facets-cloud/module-development-cli#55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions by removing references to "jq" and "Git Bash" as prerequisites.

- **Refactor**
  - Simplified command execution logic for module preview, removing platform-specific handling and related complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->