### PR TITLE
Replace bash scripts for preview and publish modules with native python code

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ dotenv
 .DS_Store
 
 .venv/
+
+# Claude AI local settings
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To install FTF CLI from source, follow these steps:
 
 #### Prerequisites
 
-- Python 3.9 or later
+- Python 3.11 or later
 - Virtual environment (recommended)
 - [jq](https://github.com/jqlang/jq)
 - [Git Bash](https://winget.run/pkg/Git/Git) 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ To install FTF CLI from source, follow these steps:
 
 - Python 3.11 or later
 - Virtual environment (recommended)
-- [jq](https://github.com/jqlang/jq)
-- [Git Bash](https://winget.run/pkg/Git/Git) 
 
 #### Steps
 

--- a/ftf_cli/operations.py
+++ b/ftf_cli/operations.py
@@ -1,0 +1,206 @@
+import os
+import json
+import zipfile
+import tempfile
+import base64
+from typing import Dict, Optional, Tuple
+import requests
+import click
+
+
+class ModuleOperationError(Exception):
+    """Custom exception for module operation errors"""
+
+    pass
+
+
+def cleanup_terraform_files(path: str) -> None:
+    """Remove .terraform directories and .terraform.lock.hcl files from the module path"""
+    import shutil
+    import glob
+
+    # Remove .terraform directories
+    terraform_dirs = glob.glob(os.path.join(path, "**/.terraform"), recursive=True)
+    for terraform_dir in terraform_dirs:
+        if os.path.isdir(terraform_dir):
+            shutil.rmtree(terraform_dir)
+
+    # Remove .terraform.lock.hcl files
+    lock_files = glob.glob(os.path.join(path, "**/.terraform.lock.hcl"), recursive=True)
+    for lock_file in lock_files:
+        if os.path.isfile(lock_file):
+            os.remove(lock_file)
+
+
+def create_module_zip(path: str) -> str:
+    """Create a zip file of the module directory and return the zip file path"""
+    # Clean up terraform files before zipping
+    cleanup_terraform_files(path)
+
+    # Create temporary zip file
+    temp_fd, zip_path = tempfile.mkstemp(suffix=".zip")
+    os.close(temp_fd)
+
+    try:
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+            for root, dirs, files in os.walk(path):
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    arcname = os.path.relpath(file_path, path)
+                    zipf.write(file_path, arcname)
+
+        return zip_path
+    except Exception as e:
+        # Clean up on error
+        if os.path.exists(zip_path):
+            os.remove(zip_path)
+        raise ModuleOperationError(f"Failed to create zip file: {str(e)}")
+
+
+def register_module(
+    control_plane_url: str,
+    username: str,
+    token: str,
+    path: str,
+    git_url: Optional[str] = None,
+    git_ref: Optional[str] = None,
+    is_feature_branch: bool = False,
+    auto_create: bool = False,
+) -> None:
+    """Register a module with the control plane"""
+
+    # Validate inputs
+    if not all([control_plane_url, username, token, path]):
+        raise ModuleOperationError("Missing required arguments for module registration")
+
+    # Validate path and facets.yaml
+    if not os.path.isdir(path):
+        raise ModuleOperationError(
+            f"Specified path '{path}' does not exist or is not a directory"
+        )
+
+    facets_yaml_path = os.path.join(path, "facets.yaml")
+    if not os.path.isfile(facets_yaml_path):
+        raise ModuleOperationError(
+            f"facets.yaml file not found in the specified path '{path}'"
+        )
+
+    # Normalize URL
+    url = control_plane_url.rstrip("/")
+    if url.startswith("http://"):
+        url = url[7:]
+    elif url.startswith("https://"):
+        url = url[8:]
+
+    upload_url = f"https://{url}/cc-ui/v1/modules/upload"
+
+    # Create zip file
+    zip_path = None
+    try:
+        zip_path = create_module_zip(path)
+
+        # Prepare authentication
+        auth_string = base64.b64encode(f"{username}:{token}".encode()).decode().strip()
+        headers = {"Authorization": f"Basic {auth_string}"}
+
+        # Prepare files for upload
+        files = {"file": ("module.zip", open(zip_path, "rb"), "application/zip")}
+
+        # Prepare metadata if git info is provided
+        if any([git_url, git_ref, is_feature_branch, auto_create]):
+            metadata = {}
+            if git_url:
+                metadata["gitUrl"] = git_url
+            if git_ref:
+                metadata["gitRef"] = git_ref
+            metadata["featureBranch"] = is_feature_branch
+            metadata["autoCreate"] = auto_create
+
+            files["metadata"] = (
+                "metadata.json",
+                json.dumps(metadata),
+                "application/json",
+            )
+
+        # Make the request
+        response = requests.post(upload_url, headers=headers, files=files)
+
+        # Close file handles
+        for file_tuple in files.values():
+            if hasattr(file_tuple[1], "close"):
+                file_tuple[1].close()
+
+        # Check response
+        if response.status_code == 200:
+            click.echo("Module registered successfully.")
+        elif 400 <= response.status_code < 600:
+            try:
+                error_message = response.json().get(
+                    "message",
+                    f"Operation failed with status code {response.status_code}",
+                )
+            except (ValueError, AttributeError):
+                error_message = (
+                    f"Operation failed with status code {response.status_code}"
+                )
+            raise ModuleOperationError(
+                f"❌ Error: {error_message} (HTTP {response.status_code})"
+            )
+        else:
+            raise ModuleOperationError(
+                f"❌ Error: Operation failed with unexpected status code {response.status_code}"
+            )
+
+    finally:
+        # Clean up zip file
+        if zip_path and os.path.exists(zip_path):
+            os.remove(zip_path)
+
+
+def publish_module(
+    control_plane_url: str,
+    username: str,
+    token: str,
+    intent: str,
+    flavor: str,
+    version: str,
+) -> None:
+    """Publish a module to make it available for production use"""
+
+    # Validate inputs
+    if not all([control_plane_url, username, token, intent, flavor, version]):
+        raise ModuleOperationError("Missing required arguments for module publishing")
+
+    # Normalize URL
+    url = control_plane_url.rstrip("/")
+    if url.startswith("http://"):
+        url = url[7:]
+    elif url.startswith("https://"):
+        url = url[8:]
+
+    publish_url = f"https://{url}/cc-ui/v1/modules/intent/{intent}/flavor/{flavor}/version/{version}/mark-published"
+
+    # Prepare authentication
+    auth_string = base64.b64encode(f"{username}:{token}".encode()).decode().strip()
+    headers = {"Authorization": f"Basic {auth_string}"}
+
+    # Make the request
+    response = requests.post(publish_url, headers=headers)
+
+    # Check response
+    if response.status_code == 200:
+        click.echo("Module marked as published successfully.")
+    elif 400 <= response.status_code < 600:
+        try:
+            error_message = response.json().get(
+                "message", f"Operation failed with status code {response.status_code}"
+            )
+        except (ValueError, AttributeError):
+            error_message = f"Operation failed with status code {response.status_code}"
+        raise ModuleOperationError(
+            f"❌ Error: {error_message} (HTTP {response.status_code})"
+        )
+    else:
+        raise ModuleOperationError(
+            f"❌ Error: Operation failed with unexpected status code {response.status_code}"
+        )

--- a/ftf_cli/operations.py
+++ b/ftf_cli/operations.py
@@ -58,14 +58,14 @@ def create_module_zip(path: str) -> str:
 
 
 def register_module(
-    control_plane_url: str,
-    username: str,
-    token: str,
-    path: str,
-    git_url: Optional[str] = None,
-    git_ref: Optional[str] = None,
-    is_feature_branch: bool = False,
-    auto_create: bool = False,
+        control_plane_url: str,
+        username: str,
+        token: str,
+        path: str,
+        git_url: Optional[str] = None,
+        git_ref: Optional[str] = None,
+        is_feature_branch: bool = False,
+        auto_create: bool = False,
 ) -> None:
     """Register a module with the control plane"""
 
@@ -103,32 +103,28 @@ def register_module(
         auth_string = base64.b64encode(f"{username}:{token}".encode()).decode().strip()
         headers = {"Authorization": f"Basic {auth_string}"}
 
-        # Prepare files for upload
-        files = {"file": ("module.zip", open(zip_path, "rb"), "application/zip")}
+        # Prepare files for upload and make the request
+        with open(zip_path, "rb") as zip_file:
+            files = {"file": ("module.zip", zip_file, "application/zip")}
 
-        # Prepare metadata if git info is provided
-        if any([git_url, git_ref, is_feature_branch, auto_create]):
-            metadata = {}
-            if git_url:
-                metadata["gitUrl"] = git_url
-            if git_ref:
-                metadata["gitRef"] = git_ref
-            metadata["featureBranch"] = is_feature_branch
-            metadata["autoCreate"] = auto_create
+            # Prepare metadata if git info is provided
+            if any([git_url, git_ref, is_feature_branch, auto_create]):
+                metadata = {}
+                if git_url:
+                    metadata["gitUrl"] = git_url
+                if git_ref:
+                    metadata["gitRef"] = git_ref
+                metadata["featureBranch"] = is_feature_branch
+                metadata["autoCreate"] = auto_create
 
-            files["metadata"] = (
-                "metadata.json",
-                json.dumps(metadata),
-                "application/json",
-            )
+                files["metadata"] = (
+                    "metadata.json",
+                    json.dumps(metadata),
+                    "application/json",
+                )
 
-        # Make the request
-        response = requests.post(upload_url, headers=headers, files=files)
-
-        # Close file handles
-        for file_tuple in files.values():
-            if hasattr(file_tuple[1], "close"):
-                file_tuple[1].close()
+            # Make the request
+            response = requests.post(upload_url, headers=headers, files=files)
 
         # Check response
         if response.status_code == 200:
@@ -158,12 +154,12 @@ def register_module(
 
 
 def publish_module(
-    control_plane_url: str,
-    username: str,
-    token: str,
-    intent: str,
-    flavor: str,
-    version: str,
+        control_plane_url: str,
+        username: str,
+        token: str,
+        intent: str,
+        flavor: str,
+        version: str,
 ) -> None:
     """Publish a module to make it available for production use"""
 

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,5 @@ setup(
         [console_scripts]
         ftf=ftf_cli.cli:cli
     """,
-    python_requires=">=3.10",
+    python_requires=">=3.11",
 )

--- a/tests/commands/test_preview_module.py
+++ b/tests/commands/test_preview_module.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 from unittest.mock import patch
 
 from ftf_cli.commands.preview_module import preview_module
-from ftf_cli.operations import ModuleOperationError
+from ftf_cli.operations import ModuleOperationError, register_module, publish_module
 
 
 @pytest.fixture

--- a/tests/commands/test_preview_module.py
+++ b/tests/commands/test_preview_module.py
@@ -1,0 +1,602 @@
+"""Integration tests for the preview_module command."""
+
+import pytest
+import os
+import tempfile
+import yaml
+import click
+from click.testing import CliRunner
+from unittest.mock import patch
+
+from ftf_cli.commands.preview_module import preview_module
+from ftf_cli.operations import ModuleOperationError
+
+
+@pytest.fixture
+def runner():
+    """Provide a Click CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_credentials():
+    """Mock credentials for authentication."""
+    return {
+        "control_plane_url": "https://test.facets.cloud",
+        "username": "testuser",
+        "token": "testtoken",
+    }
+
+
+@pytest.fixture
+def temp_module_with_facets(tmp_path):
+    """Create a temporary module directory with facets.yaml."""
+    module_dir = tmp_path / "test_module"
+    module_dir.mkdir()
+
+    # Create facets.yaml
+    facets_yaml = module_dir / "facets.yaml"
+    facets_content = {
+        "intent": "test-intent",
+        "flavor": "test-flavor",
+        "version": "1.0",
+        "sample": {
+            "version": "1.0",
+            "kind": "test-intent",
+            "flavor": "test-flavor",
+            "spec": {},
+        },
+        "description": "Test description",
+        "clouds": ["aws", "azure", "gcp", "kubernetes"],
+        "spec": {},
+    }
+    facets_yaml.write_text(yaml.dump(facets_content))
+
+    # Create basic terraform files
+    main_tf = module_dir / "main.tf"
+    main_tf.write_text('resource "aws_instance" "test" {}')
+
+    variables_tf = module_dir / "variables.tf"
+    variables_tf.write_text('variable "region" { type = string }')
+
+    return str(module_dir)
+
+
+@pytest.fixture
+def temp_module_with_outputs(temp_module_with_facets):
+    """Create a module with outputs.tf for testing output tree generation."""
+    module_dir = temp_module_with_facets
+    outputs_tf = os.path.join(module_dir, "outputs.tf")
+
+    outputs_content = """
+locals {
+  output_interfaces = {
+    "interface1" = "value1"
+  }
+  output_attributes = {
+    "attr1" = "value1"
+  }
+}
+"""
+
+    with open(outputs_tf, "w") as f:
+        f.write(outputs_content)
+
+    return module_dir
+
+
+class TestPreviewModuleCommand:
+    """Test cases for the preview_module command."""
+
+    @patch("ftf_cli.commands.preview_module.is_logged_in")
+    @patch("ftf_cli.commands.preview_module.validate_directory.invoke")
+    @patch("ftf_cli.commands.preview_module.register_module")
+    def test_basic_preview_success(
+        self,
+        mock_register,
+        mock_validate_invoke,
+        mock_is_logged_in,
+        runner,
+        temp_module_with_facets,
+        mock_credentials,
+    ):
+        """Test basic successful module preview."""
+        # Setup mocks
+        mock_is_logged_in.return_value = mock_credentials
+        mock_validate_invoke.return_value = None
+        mock_register.return_value = None
+
+        # Run command with explicit profile
+        result = runner.invoke(
+            preview_module, [temp_module_with_facets, "--profile", "default"]
+        )
+
+        # Assertions
+        assert result.exit_code == 0
+        assert "Profile selected: default" in result.output
+        assert "✔ Module preview successfully registered." in result.output
+        assert (
+            '[PREVIEW] Module with Intent "test-intent", Flavor "test-flavor"'
+            in result.output
+        )
+
+        # Verify register_module was called with correct parameters
+        mock_register.assert_called_once()
+        call_args = mock_register.call_args
+        assert call_args[1]["control_plane_url"] == "https://test.facets.cloud"
+        assert call_args[1]["username"] == "testuser"
+        assert call_args[1]["token"] == "testtoken"
+        assert call_args[1]["path"] == temp_module_with_facets
+        assert call_args[1]["is_feature_branch"] is True  # Default when not publishable
+        assert call_args[1]["auto_create"] is False
+
+    @patch("ftf_cli.commands.preview_module.is_logged_in")
+    @patch("ftf_cli.commands.preview_module.validate_directory.invoke")
+    @patch("ftf_cli.commands.preview_module.register_module")
+    @patch("ftf_cli.commands.preview_module.publish_module")
+    def test_preview_with_publish_success(
+        self,
+        mock_publish,
+        mock_register,
+        mock_validate_invoke,
+        mock_is_logged_in,
+        runner,
+        temp_module_with_facets,
+        mock_credentials,
+    ):
+        """Test successful preview and publish flow."""
+        # Setup mocks
+        mock_is_logged_in.return_value = mock_credentials
+        mock_validate_invoke.return_value = None
+        mock_register.return_value = None
+        mock_publish.return_value = None
+
+        # Run command with git env vars and explicit profile
+        with patch.dict(
+            os.environ,
+            {"GIT_REPO_URL": "https://github.com/test/repo", "GIT_REF": "main"},
+        ):
+            result = runner.invoke(
+                preview_module,
+                [
+                    temp_module_with_facets,
+                    "--profile",
+                    "default",
+                    "--publish",
+                    "true",
+                    "--publishable",
+                    "true",
+                ],
+            )
+
+        # Assertions
+        assert result.exit_code == 0
+        assert "Profile selected: default" in result.output
+        assert "✔ Module preview successfully registered." in result.output
+        assert (
+            '[PUBLISH] Module with Intent "test-intent", Flavor "test-flavor"'
+            in result.output
+        )
+
+        # Verify both register and publish were called
+        mock_register.assert_called_once()
+        mock_publish.assert_called_once()
+
+        # Verify publish was called with correct parameters
+        publish_call_args = mock_publish.call_args
+        assert publish_call_args[1]["intent"] == "test-intent"
+        assert publish_call_args[1]["flavor"] == "test-flavor"
+        assert publish_call_args[1]["version"] == "1.0"
+
+    @patch("ftf_cli.commands.preview_module.is_logged_in")
+    @patch("ftf_cli.commands.preview_module.validate_directory.invoke")
+    @patch("ftf_cli.commands.preview_module.register_module")
+    def test_preview_with_git_parameters(
+        self,
+        mock_register,
+        mock_validate_invoke,
+        mock_is_logged_in,
+        runner,
+        temp_module_with_facets,
+        mock_credentials,
+    ):
+        """Test preview with git URL and reference parameters."""
+        # Setup mocks
+        mock_is_logged_in.return_value = mock_credentials
+        mock_validate_invoke.return_value = None
+        mock_register.return_value = None
+
+        # Run command with git parameters and explicit profile
+        result = runner.invoke(
+            preview_module,
+            [
+                temp_module_with_facets,
+                "--profile",
+                "default",
+                "--git-repo-url",
+                "https://github.com/test/repo",
+                "--git-ref",
+                "feature-branch",
+                "--auto-create-intent",
+                "true",
+            ],
+        )
+
+        # Assertions
+        assert result.exit_code == 0
+        assert "Profile selected: default" in result.output
+        assert "Git repository URL: https://github.com/test/repo" in result.output
+        assert "Git reference: feature-branch" in result.output
+        assert "Auto-create intent: True" in result.output
+
+        # Verify register_module was called with git parameters
+        call_args = mock_register.call_args
+        assert call_args[1]["git_url"] == "https://github.com/test/repo"
+        assert call_args[1]["git_ref"] == "feature-branch"
+        assert call_args[1]["auto_create"] is True
+
+    @patch("ftf_cli.commands.preview_module.is_logged_in")
+    def test_preview_not_logged_in(
+        self, mock_is_logged_in, runner, temp_module_with_facets
+    ):
+        """Test preview command when user is not logged in."""
+        # Setup mock to return None (not logged in)
+        mock_is_logged_in.return_value = None
+
+        # Run command with explicit profile
+        result = runner.invoke(
+            preview_module, [temp_module_with_facets, "--profile", "default"]
+        )
+
+        # Assertions
+        assert result.exit_code == 2  # Click UsageError exit code
+        assert "❌ Not logged in under profile default" in result.output
+
+    @patch("ftf_cli.commands.preview_module.is_logged_in")
+    @patch("ftf_cli.commands.preview_module.validate_directory.invoke")
+    def test_preview_validation_failure(
+        self,
+        mock_validate_invoke,
+        mock_is_logged_in,
+        runner,
+        temp_module_with_facets,
+        mock_credentials,
+    ):
+        """Test preview command when directory validation fails."""
+        # Setup mocks
+        mock_is_logged_in.return_value = mock_credentials
+        mock_validate_invoke.side_effect = click.ClickException("Validation failed")
+
+        # Run command with explicit profile
+        result = runner.invoke(
+            preview_module, [temp_module_with_facets, "--profile", "default"]
+        )
+
+        # Assertions
+        assert result.exit_code == 2
+        assert "❌ Validation failed" in result.output
+
+    @patch("ftf_cli.commands.preview_module.is_logged_in")
+    @patch("ftf_cli.commands.preview_module.validate_directory.invoke")
+    @patch("ftf_cli.commands.preview_module.register_module")
+    def test_preview_registration_failure(
+        self,
+        mock_register,
+        mock_validate_invoke,
+        mock_is_logged_in,
+        runner,
+        temp_module_with_facets,
+        mock_credentials,
+    ):
+        """Test preview command when module registration fails."""
+        # Setup mocks
+        mock_is_logged_in.return_value = mock_credentials
+        mock_validate_invoke.return_value = None
+        mock_register.side_effect = ModuleOperationError("Registration failed")
+
+        # Run command with explicit profile
+        result = runner.invoke(
+            preview_module, [temp_module_with_facets, "--profile", "default"]
+        )
+
+        # Assertions
+        assert result.exit_code == 2
+        assert (
+            "❌ Failed to register module for preview: Registration failed"
+            in result.output
+        )
+
+    @patch("ftf_cli.commands.preview_module.is_logged_in")
+    @patch("ftf_cli.commands.preview_module.validate_directory.invoke")
+    @patch("ftf_cli.commands.preview_module.register_module")
+    @patch("ftf_cli.commands.preview_module.publish_module")
+    def test_preview_publish_failure(
+        self,
+        mock_publish,
+        mock_register,
+        mock_validate_invoke,
+        mock_is_logged_in,
+        runner,
+        temp_module_with_facets,
+        mock_credentials,
+    ):
+        """Test preview command when publishing fails."""
+        # Setup mocks
+        mock_is_logged_in.return_value = mock_credentials
+        mock_validate_invoke.return_value = None
+        mock_register.return_value = None
+        mock_publish.side_effect = ModuleOperationError("Publishing failed")
+
+        # Set environment variables for non-local development
+        with patch.dict(
+            os.environ,
+            {"GIT_REPO_URL": "https://github.com/test/repo", "GIT_REF": "main"},
+        ):
+            result = runner.invoke(
+                preview_module,
+                [temp_module_with_facets, "--profile", "default", "--publish", "true"],
+            )
+
+        # Assertions
+        assert result.exit_code == 2
+        assert "❌ Failed to Publish module: Publishing failed" in result.output
+
+    @patch("ftf_cli.commands.preview_module.is_logged_in")
+    @patch("ftf_cli.commands.preview_module.validate_directory.invoke")
+    @patch("ftf_cli.commands.preview_module.register_module")
+    def test_local_development_version_handling(
+        self,
+        mock_register,
+        mock_validate_invoke,
+        mock_is_logged_in,
+        runner,
+        temp_module_with_facets,
+        mock_credentials,
+    ):
+        """Test that local development versions are properly modified and reverted."""
+        # Setup mocks
+        mock_is_logged_in.return_value = mock_credentials
+        mock_validate_invoke.return_value = None
+        mock_register.return_value = None
+
+        # Run command with local git ref and explicit profile
+        result = runner.invoke(
+            preview_module,
+            [
+                temp_module_with_facets,
+                "--profile",
+                "default",
+                "--git-ref",
+                "local-testuser",
+            ],
+        )
+
+        # Assertions
+        assert result.exit_code == 0
+        assert "Profile selected: default" in result.output
+        assert "Version modified to: 1.0-local-testuser" in result.output
+        assert "Sample version modified to: 1.0-local-testuser" in result.output
+        assert "Version reverted to: 1.0" in result.output
+        assert "Sample version reverted to: 1.0" in result.output
+
+        # Verify the final facets.yaml was reverted
+        with open(os.path.join(temp_module_with_facets, "facets.yaml"), "r") as f:
+            final_facets = yaml.safe_load(f)
+        assert final_facets["version"] == "1.0"
+        assert final_facets["sample"]["version"] == "1.0"
+
+    @patch("ftf_cli.commands.preview_module.is_logged_in")
+    @patch("ftf_cli.commands.preview_module.validate_directory.invoke")
+    @patch("ftf_cli.commands.preview_module.register_module")
+    def test_local_development_publish_prevention(
+        self,
+        mock_register,
+        mock_validate_invoke,
+        mock_is_logged_in,
+        runner,
+        temp_module_with_facets,
+        mock_credentials,
+    ):
+        """Test that local development modules cannot be published."""
+        # Setup mocks
+        mock_is_logged_in.return_value = mock_credentials
+        mock_validate_invoke.return_value = None
+        mock_register.return_value = None
+
+        # Run command with local git ref and publish flag
+        result = runner.invoke(
+            preview_module,
+            [
+                temp_module_with_facets,
+                "--profile",
+                "default",
+                "--git-ref",
+                "local-testuser",
+                "--publish",
+                "true",
+            ],
+        )
+
+        # Assertions
+        assert result.exit_code == 2
+        assert "❌ Cannot publish a local development module" in result.output
+
+    @patch("ftf_cli.commands.preview_module.is_logged_in")
+    @patch("ftf_cli.commands.preview_module.validate_directory.invoke")
+    @patch("ftf_cli.commands.preview_module.register_module")
+    def test_output_tree_generation_and_cleanup(
+        self,
+        mock_register,
+        mock_validate_invoke,
+        mock_is_logged_in,
+        runner,
+        temp_module_with_outputs,
+        mock_credentials,
+    ):
+        """Test that output tree is generated and cleaned up properly."""
+        # Setup mocks
+        mock_is_logged_in.return_value = mock_credentials
+        mock_validate_invoke.return_value = None
+        mock_register.return_value = None
+
+        # Run command with explicit profile
+        result = runner.invoke(
+            preview_module, [temp_module_with_outputs, "--profile", "default"]
+        )
+
+        # Assertions
+        assert result.exit_code == 0
+        assert "Profile selected: default" in result.output
+        assert "Output lookup tree saved to" in result.output
+        assert "Removed temporary file:" in result.output
+
+        # Verify cleanup - output-lookup-tree.json should be removed
+        output_json = os.path.join(temp_module_with_outputs, "output-lookup-tree.json")
+        assert not os.path.exists(output_json)
+
+    @patch("ftf_cli.commands.preview_module.is_logged_in")
+    @patch("ftf_cli.commands.preview_module.validate_directory.invoke")
+    @patch("ftf_cli.commands.preview_module.register_module")
+    def test_missing_git_env_vars_warning(
+        self,
+        mock_register,
+        mock_validate_invoke,
+        mock_is_logged_in,
+        runner,
+        temp_module_with_facets,
+        mock_credentials,
+    ):
+        """Test warning when GIT_REPO_URL and GIT_REF are not set."""
+        # Setup mocks
+        mock_is_logged_in.return_value = mock_credentials
+        mock_validate_invoke.return_value = None
+        mock_register.return_value = None
+
+        # Ensure git env vars are not set
+        with patch.dict(os.environ, {}, clear=True):
+            result = runner.invoke(
+                preview_module, [temp_module_with_facets, "--profile", "default"]
+            )
+
+        # Assertions
+        assert result.exit_code == 0
+        assert "Profile selected: default" in result.output
+        assert (
+            "⚠️  CI related env vars: GIT_REPO_URL and GIT_REF not set" in result.output
+        )
+
+    @patch("ftf_cli.commands.preview_module.is_logged_in")
+    @patch("ftf_cli.commands.preview_module.validate_directory.invoke")
+    @patch("ftf_cli.commands.preview_module.register_module")
+    def test_custom_profile(
+        self,
+        mock_register,
+        mock_validate_invoke,
+        mock_is_logged_in,
+        runner,
+        temp_module_with_facets,
+        mock_credentials,
+    ):
+        """Test preview command with custom profile."""
+        # Setup mocks
+        mock_is_logged_in.return_value = mock_credentials
+        mock_validate_invoke.return_value = None
+        mock_register.return_value = None
+
+        # Run command with custom profile
+        result = runner.invoke(
+            preview_module, [temp_module_with_facets, "--profile", "custom-profile"]
+        )
+
+        # Assertions
+        assert result.exit_code == 0
+        assert "Profile selected: custom-profile" in result.output
+
+        # Verify is_logged_in was called with custom profile
+        mock_is_logged_in.assert_called_with("custom-profile")
+
+    def test_missing_facets_yaml(self, runner):
+        """Test preview command with directory missing facets.yaml."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create empty directory without facets.yaml
+            result = runner.invoke(preview_module, [temp_dir, "--profile", "default"])
+
+            # Should fail during validation
+            assert result.exit_code == 2
+
+    @patch("ftf_cli.commands.preview_module.is_logged_in")
+    @patch("ftf_cli.commands.preview_module.validate_directory.invoke")
+    @patch("ftf_cli.commands.preview_module.register_module")
+    def test_output_tree_missing_outputs_tf(
+        self,
+        mock_register,
+        mock_validate_invoke,
+        mock_is_logged_in,
+        runner,
+        temp_module_with_facets,
+        mock_credentials,
+    ):
+        """Test behavior when outputs.tf is missing."""
+        # Setup mocks
+        mock_is_logged_in.return_value = mock_credentials
+        mock_validate_invoke.return_value = None
+        mock_register.return_value = None
+
+        # Run command (temp_module_with_facets doesn't have outputs.tf)
+        result = runner.invoke(
+            preview_module, [temp_module_with_facets, "--profile", "default"]
+        )
+
+        # Assertions
+        assert result.exit_code == 0
+        assert "Profile selected: default" in result.output
+        assert "Warning: " in result.output and "outputs.tf not found" in result.output
+        assert "Skipping output tree generation" in result.output
+
+
+class TestPreviewModuleEdgeCases:
+    """Test edge cases and error conditions."""
+
+    @patch("ftf_cli.commands.preview_module.is_logged_in")
+    @patch("ftf_cli.commands.preview_module.validate_directory.invoke")
+    @patch("ftf_cli.commands.preview_module.register_module")
+    def test_boolean_parameter_validation(
+        self,
+        mock_register,
+        mock_validate_invoke,
+        mock_is_logged_in,
+        runner,
+        temp_module_with_facets,
+        mock_credentials,
+    ):
+        """Test validation of boolean parameters."""
+        # Setup mocks
+        mock_is_logged_in.return_value = mock_credentials
+        mock_validate_invoke.return_value = None
+        mock_register.return_value = None
+
+        # Test with valid boolean values
+        result = runner.invoke(
+            preview_module,
+            [
+                temp_module_with_facets,
+                "--profile",
+                "default",
+                "--auto-create-intent",
+                "yes",
+                "--publishable",
+                "no",
+                "--publish",
+                "false",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Profile selected: default" in result.output
+
+        # Verify the boolean conversion worked correctly
+        call_args = mock_register.call_args
+        assert call_args[1]["auto_create"] is True  # 'yes' -> True
+        assert (
+            call_args[1]["is_feature_branch"] is True
+        )  # publishable=no -> feature_branch=True

--- a/tests/commands/test_preview_module.py
+++ b/tests/commands/test_preview_module.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 from unittest.mock import patch
 
 from ftf_cli.commands.preview_module import preview_module
-from ftf_cli.operations import ModuleOperationError, register_module, publish_module
+from ftf_cli.operations import ModuleOperationError
 
 
 @pytest.fixture

--- a/tests/test_module_operations.py
+++ b/tests/test_module_operations.py
@@ -1,0 +1,173 @@
+import pytest
+import tempfile
+import os
+from unittest.mock import Mock, patch
+from ftf_cli.operations import (
+    register_module,
+    publish_module,
+    ModuleOperationError,
+    cleanup_terraform_files,
+    create_module_zip,
+)
+
+
+class TestModuleOperations:
+
+    def test_cleanup_terraform_files(self):
+        """Test that terraform files are properly cleaned up"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create test terraform files
+            terraform_dir = os.path.join(temp_dir, ".terraform")
+            os.makedirs(terraform_dir)
+
+            lock_file = os.path.join(temp_dir, ".terraform.lock.hcl")
+            with open(lock_file, "w") as f:
+                f.write("test")
+
+            # Cleanup should remove these files
+            cleanup_terraform_files(temp_dir)
+
+            assert not os.path.exists(terraform_dir)
+            assert not os.path.exists(lock_file)
+
+    def test_create_module_zip(self):
+        """Test module zip creation"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create test files
+            test_file = os.path.join(temp_dir, "test.txt")
+            with open(test_file, "w") as f:
+                f.write("test content")
+
+            zip_path = create_module_zip(temp_dir)
+
+            try:
+                assert os.path.exists(zip_path)
+                assert zip_path.endswith(".zip")
+            finally:
+                if os.path.exists(zip_path):
+                    os.remove(zip_path)
+
+    @patch("requests.post")
+    def test_register_module_success(self, mock_post):
+        """Test successful module registration"""
+        # Mock successful response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create facets.yaml
+            facets_file = os.path.join(temp_dir, "facets.yaml")
+            with open(facets_file, "w") as f:
+                f.write("intent: test\nflavor: default\nversion: 1.0\n")
+
+            # Should not raise an exception
+            register_module(
+                control_plane_url="https://test.example.com",
+                username="testuser",
+                token="testtoken",
+                path=temp_dir,
+            )
+
+            # Verify the request was made
+            mock_post.assert_called_once()
+
+    @patch("requests.post")
+    def test_register_module_error(self, mock_post):
+        """Test module registration error handling"""
+        # Mock error response
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_response.json.return_value = {"message": "Bad Request"}
+        mock_post.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create facets.yaml
+            facets_file = os.path.join(temp_dir, "facets.yaml")
+            with open(facets_file, "w") as f:
+                f.write("intent: test\nflavor: default\nversion: 1.0\n")
+
+            with pytest.raises(ModuleOperationError):
+                register_module(
+                    control_plane_url="https://test.example.com",
+                    username="testuser",
+                    token="testtoken",
+                    path=temp_dir,
+                )
+
+    @patch("requests.post")
+    def test_publish_module_success(self, mock_post):
+        """Test successful module publishing"""
+        # Mock successful response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        # Should not raise an exception
+        publish_module(
+            control_plane_url="https://test.example.com",
+            username="testuser",
+            token="testtoken",
+            intent="test",
+            flavor="default",
+            version="1.0",
+        )
+
+        # Verify the request was made
+        mock_post.assert_called_once()
+
+    @patch("requests.post")
+    def test_publish_module_error(self, mock_post):
+        """Test module publishing error handling"""
+        # Mock error response
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.json.return_value = {"message": "Internal Server Error"}
+        mock_post.return_value = mock_response
+
+        with pytest.raises(ModuleOperationError):
+            publish_module(
+                control_plane_url="https://test.example.com",
+                username="testuser",
+                token="testtoken",
+                intent="test",
+                flavor="default",
+                version="1.0",
+            )
+
+    def test_register_module_missing_facets_yaml(self):
+        """Test registration fails when facets.yaml is missing"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with pytest.raises(
+                ModuleOperationError, match="facets.yaml file not found"
+            ):
+                register_module(
+                    control_plane_url="https://test.example.com",
+                    username="testuser",
+                    token="testtoken",
+                    path=temp_dir,
+                )
+
+    def test_register_module_invalid_path(self):
+        """Test registration fails with invalid path"""
+        with pytest.raises(
+            ModuleOperationError, match="does not exist or is not a directory"
+        ):
+            register_module(
+                control_plane_url="https://test.example.com",
+                username="testuser",
+                token="testtoken",
+                path="/nonexistent/path",
+            )
+
+    def test_publish_module_missing_args(self):
+        """Test publishing fails with missing arguments"""
+        with pytest.raises(ModuleOperationError, match="Missing required arguments"):
+            publish_module(
+                control_plane_url="",
+                username="testuser",
+                token="testtoken",
+                intent="test",
+                flavor="default",
+                version="1.0",
+            )


### PR DESCRIPTION
Fixes #56 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the module preview command for improved reliability and maintainability by using internal Python functions instead of shell commands.
- **New Features**
  - Introduced new operations for registering and publishing Terraform modules directly with a control plane.
- **Bug Fixes**
  - Enhanced error handling and user feedback during module registration and publishing.
- **Tests**
  - Added comprehensive tests for module operations and the preview command, including edge cases and error scenarios.
- **Chores**
  - Updated ignore rules to exclude local settings files from version control.
- **Documentation**
  - Updated minimum required Python version in installation instructions and package configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->