### PR TITLE
Validate that provider blocks are not present in tf files

### DIFF
--- a/ftf_cli/commands/validate_directory.py
+++ b/ftf_cli/commands/validate_directory.py
@@ -4,6 +4,7 @@ from ftf_cli.utils import (
     validate_facets_yaml,
     validate_boolean,
     validate_facets_tf_vars,
+    validate_no_provider_blocks,
 )
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.runner import Runner
@@ -60,6 +61,9 @@ def validate_directory(path, check_only, skip_terraform_validation):
             if check_only
             else "🎨 Terraform files formatted."
         )
+
+        # Validate no provider blocks exist in .tf files
+        validate_no_provider_blocks(path)
 
         if not skip_terraform_validation:
             # Run terraform init and validate

--- a/tests/commands/test_validate_directory.py
+++ b/tests/commands/test_validate_directory.py
@@ -1,0 +1,174 @@
+import pytest
+import tempfile
+import os
+from click.testing import CliRunner
+from unittest.mock import patch, MagicMock
+from ftf_cli.commands.validate_directory import validate_directory
+
+
+class TestValidateDirectoryProviderValidation:
+    """Test provider validation integration in validate_directory command."""
+
+    def test_validate_directory_with_provider_blocks_fails(self):
+        """Test that validate_directory fails when provider blocks are present."""
+        runner = CliRunner()
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a module with provider block
+            main_tf = os.path.join(temp_dir, "main.tf")
+            with open(main_tf, "w") as f:
+                f.write('''
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_instance" "test" {
+  ami = "ami-123"
+}
+''')
+            
+            variables_tf = os.path.join(temp_dir, "variables.tf")
+            with open(variables_tf, "w") as f:
+                f.write('''
+variable "instance" {
+  description = "Instance configuration"
+  type = object({
+    kind    = string
+    flavor  = string
+    version = string
+  })
+}
+
+variable "instance_name" {
+  description = "Instance name"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment"
+  type        = string
+}
+
+variable "inputs" {
+  description = "Inputs"
+  type        = object({})
+}
+''')
+            
+            facets_yaml = os.path.join(temp_dir, "facets.yaml")
+            with open(facets_yaml, "w") as f:
+                f.write('''
+intent: test-intent
+flavor: test-flavor
+version: "1.0"
+description: Test module for provider validation
+clouds:
+  - aws
+spec:
+  type: object
+  properties: {}
+''')
+            
+            # Mock external dependencies to focus on provider validation
+            with patch('ftf_cli.commands.validate_directory.run') as mock_run:
+                # Mock terraform version check to succeed
+                mock_run.return_value.returncode = 0
+                
+                # Mock the other validation steps to pass
+                with patch('ftf_cli.utils.validate_facets_yaml') as mock_validate_yaml, \
+                     patch('ftf_cli.utils.validate_facets_tf_vars') as mock_validate_vars:
+                    
+                    mock_validate_yaml.return_value = True
+                    mock_validate_vars.return_value = True
+                    
+                    # Run the command
+                    result = runner.invoke(validate_directory, [temp_dir, '--skip-terraform-validation', 'true'])
+                    
+                    # Should fail due to provider blocks
+                    assert result.exit_code != 0
+                    assert "Provider blocks are not allowed in module files" in result.output
+                    assert "main.tf" in result.output
+
+    def test_validate_directory_without_provider_blocks_continues(self):
+        """Test that validate_directory continues when no provider blocks are present."""
+        runner = CliRunner()
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a module without provider blocks
+            main_tf = os.path.join(temp_dir, "main.tf")
+            with open(main_tf, "w") as f:
+                f.write('''
+resource "aws_instance" "test" {
+  ami = "ami-123456"
+}
+''')
+            
+            variables_tf = os.path.join(temp_dir, "variables.tf")
+            with open(variables_tf, "w") as f:
+                f.write('''
+variable "instance" {
+  description = "Instance configuration"
+  type = object({
+    kind    = string
+    flavor  = string
+    version = string
+  })
+}
+
+variable "instance_name" {
+  description = "Instance name"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment"
+  type        = string
+}
+
+variable "inputs" {
+  description = "Inputs"
+  type        = object({})
+}
+''')
+            
+            facets_yaml = os.path.join(temp_dir, "facets.yaml")
+            with open(facets_yaml, "w") as f:
+                f.write('''
+intent: test-intent
+flavor: test-flavor
+version: "1.0"
+description: Test module for provider validation
+clouds:
+  - aws
+spec:
+  type: object
+  properties: {}
+''')
+            
+            # Mock external dependencies
+            with patch('ftf_cli.commands.validate_directory.run') as mock_run:
+                # Mock terraform version check to succeed
+                mock_run.return_value.returncode = 0
+                
+                # Mock the checkov validation to pass
+                with patch('ftf_cli.utils.validate_facets_yaml') as mock_validate_yaml, \
+                     patch('ftf_cli.utils.validate_facets_tf_vars') as mock_validate_vars, \
+                     patch('checkov.terraform.runner.Runner') as mock_runner_class:
+                    
+                    mock_validate_yaml.return_value = True
+                    mock_validate_vars.return_value = True
+                    
+                    # Mock Checkov runner
+                    mock_runner = MagicMock()
+                    mock_runner_class.return_value = mock_runner
+                    mock_report = MagicMock()
+                    mock_report.failed_checks = []  # No failed checks
+                    mock_runner.run.return_value = mock_report
+                    
+                    # Run the command
+                    result = runner.invoke(validate_directory, [temp_dir, '--skip-terraform-validation', 'true'])
+                    
+                    # Should pass provider validation and continue
+                    assert "No provider blocks found in Terraform files" in result.output
+                    # Should not fail due to provider validation
+                    assert "Provider blocks are not allowed" not in result.output

--- a/tests/commands/test_validate_directory.py
+++ b/tests/commands/test_validate_directory.py
@@ -172,3 +172,210 @@ spec:
                     assert "No provider blocks found in Terraform files" in result.output
                     # Should not fail due to provider validation
                     assert "Provider blocks are not allowed" not in result.output
+
+
+    def test_validate_directory_detects_nested_provider_blocks(self):
+        """Test that validate_directory detects provider blocks in nested directories."""
+        runner = CliRunner()
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create main module without provider blocks
+            main_tf = os.path.join(temp_dir, "main.tf")
+            with open(main_tf, "w") as f:
+                f.write('''
+resource "aws_instance" "test" {
+  ami = "ami-123456"
+}
+''')
+            
+            # Create nested directory with provider block
+            nested_dir = os.path.join(temp_dir, "modules", "vpc")
+            os.makedirs(nested_dir)
+            nested_tf = os.path.join(nested_dir, "vpc.tf")
+            with open(nested_tf, "w") as f:
+                f.write('''
+provider "aws" {
+  region = "us-east-1"
+  alias  = "east"
+}
+
+resource "aws_vpc" "nested" {
+  cidr_block = "10.0.0.0/16"
+}
+''')
+            
+            variables_tf = os.path.join(temp_dir, "variables.tf")
+            with open(variables_tf, "w") as f:
+                f.write('''
+variable "instance" {
+  description = "Instance configuration"
+  type = object({
+    kind    = string
+    flavor  = string
+    version = string
+  })
+}
+
+variable "instance_name" {
+  description = "Instance name"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment"
+  type        = string
+}
+
+variable "inputs" {
+  description = "Inputs"
+  type        = object({})
+}
+''')
+            
+            facets_yaml = os.path.join(temp_dir, "facets.yaml")
+            with open(facets_yaml, "w") as f:
+                f.write('''
+intent: test-intent
+flavor: test-flavor
+version: "1.0"
+description: Test module for provider validation
+clouds:
+  - aws
+spec:
+  type: object
+  properties: {}
+''')
+            
+            # Mock external dependencies to focus on provider validation
+            with patch('ftf_cli.commands.validate_directory.run') as mock_run:
+                # Mock terraform version check to succeed
+                mock_run.return_value.returncode = 0
+                
+                # Mock the other validation steps to pass
+                with patch('ftf_cli.utils.validate_facets_yaml') as mock_validate_yaml, \
+                     patch('ftf_cli.utils.validate_facets_tf_vars') as mock_validate_vars:
+                    
+                    mock_validate_yaml.return_value = True
+                    mock_validate_vars.return_value = True
+                    
+                    # Run the command
+                    result = runner.invoke(validate_directory, [temp_dir, '--skip-terraform-validation', 'true'])
+                    
+                    # Should fail due to provider blocks in nested directory
+                    assert result.exit_code != 0
+                    assert "Provider blocks are not allowed in module files" in result.output
+                    assert "modules/vpc/vpc.tf" in result.output
+
+    def test_validate_directory_with_multiple_nested_provider_blocks(self):
+        """Test that validate_directory detects provider blocks in multiple nested locations."""
+        runner = CliRunner()
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create provider block in root
+            main_tf = os.path.join(temp_dir, "main.tf")
+            with open(main_tf, "w") as f:
+                f.write('''
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_instance" "test" {
+  ami = "ami-123456"
+}
+''')
+            
+            # Create provider block in first nested directory
+            nested_dir1 = os.path.join(temp_dir, "modules", "vpc")
+            os.makedirs(nested_dir1)
+            nested_tf1 = os.path.join(nested_dir1, "vpc.tf")
+            with open(nested_tf1, "w") as f:
+                f.write('''
+provider "aws" {
+  region = "us-east-1"
+  alias  = "east"
+}
+
+resource "aws_vpc" "nested" {
+  cidr_block = "10.0.0.0/16"
+}
+''')
+            
+            # Create provider block in second nested directory
+            nested_dir2 = os.path.join(temp_dir, "submodules")
+            os.makedirs(nested_dir2)
+            nested_tf2 = os.path.join(nested_dir2, "database.tf")
+            with open(nested_tf2, "w") as f:
+                f.write('''
+provider "postgresql" {
+  host = "localhost"
+}
+
+resource "postgresql_database" "test" {
+  name = "testdb"
+}
+''')
+            
+            variables_tf = os.path.join(temp_dir, "variables.tf")
+            with open(variables_tf, "w") as f:
+                f.write('''
+variable "instance" {
+  description = "Instance configuration"
+  type = object({
+    kind    = string
+    flavor  = string
+    version = string
+  })
+}
+
+variable "instance_name" {
+  description = "Instance name"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment"
+  type        = string
+}
+
+variable "inputs" {
+  description = "Inputs"
+  type        = object({})
+}
+''')
+            
+            facets_yaml = os.path.join(temp_dir, "facets.yaml")
+            with open(facets_yaml, "w") as f:
+                f.write('''
+intent: test-intent
+flavor: test-flavor
+version: "1.0"
+description: Test module for provider validation
+clouds:
+  - aws
+spec:
+  type: object
+  properties: {}
+''')
+            
+            # Mock external dependencies to focus on provider validation
+            with patch('ftf_cli.commands.validate_directory.run') as mock_run:
+                # Mock terraform version check to succeed
+                mock_run.return_value.returncode = 0
+                
+                # Mock the other validation steps to pass
+                with patch('ftf_cli.utils.validate_facets_yaml') as mock_validate_yaml, \
+                     patch('ftf_cli.utils.validate_facets_tf_vars') as mock_validate_vars:
+                    
+                    mock_validate_yaml.return_value = True
+                    mock_validate_vars.return_value = True
+                    
+                    # Run the command
+                    result = runner.invoke(validate_directory, [temp_dir, '--skip-terraform-validation', 'true'])
+                    
+                    # Should fail due to provider blocks in multiple locations
+                    assert result.exit_code != 0
+                    assert "Provider blocks are not allowed in module files" in result.output
+                    # Should detect all three files with provider blocks
+                    assert "main.tf" in result.output
+                    assert "modules/vpc/vpc.tf" in result.output
+                    assert "submodules/database.tf" in result.output

--- a/tests/test_data/module_multiple_providers/azure.tf
+++ b/tests/test_data/module_multiple_providers/azure.tf
@@ -1,0 +1,9 @@
+# Additional file with provider block
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "test-rg"
+  location = "West US"
+}

--- a/tests/test_data/module_multiple_providers/main.tf
+++ b/tests/test_data/module_multiple_providers/main.tf
@@ -1,0 +1,16 @@
+# Module with multiple providers - should fail validation
+provider "aws" {
+  region = "us-west-2"
+  alias  = "west"
+}
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "east"
+}
+
+resource "aws_instance" "west_instance" {
+  provider      = aws.west
+  ami           = "ami-12345"
+  instance_type = "t2.micro"
+}

--- a/tests/test_data/module_with_provider/main.tf
+++ b/tests/test_data/module_with_provider/main.tf
@@ -1,0 +1,13 @@
+# Module with provider block - should fail validation
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_instance" "test" {
+  ami           = "ami-12345"
+  instance_type = "t2.micro"
+  
+  tags = {
+    Name = "test-instance"
+  }
+}

--- a/tests/test_data/module_with_provider/variables.tf
+++ b/tests/test_data/module_with_provider/variables.tf
@@ -1,0 +1,11 @@
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-west-2"
+}

--- a/tests/test_data/module_without_provider/facets.yaml
+++ b/tests/test_data/module_without_provider/facets.yaml
@@ -1,0 +1,12 @@
+intent: test-intent
+flavor: test-flavor
+version: "1.0"
+description: Test module without provider blocks
+clouds:
+  - aws
+spec:
+  type: object
+  properties:
+    instance_type:
+      type: string
+      default: t2.micro

--- a/tests/test_data/module_without_provider/main.tf
+++ b/tests/test_data/module_without_provider/main.tf
@@ -1,0 +1,20 @@
+# Module without provider block - should pass validation
+resource "aws_instance" "test" {
+  ami           = var.ami_id
+  instance_type = var.instance_type
+
+  tags = {
+    Name = var.instance_name
+  }
+}
+
+resource "aws_security_group" "test" {
+  name_prefix = "test-sg"
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/tests/test_data/module_without_provider/outputs.tf
+++ b/tests/test_data/module_without_provider/outputs.tf
@@ -1,0 +1,9 @@
+output "instance_id" {
+  description = "ID of the EC2 instance"
+  value       = aws_instance.test.id
+}
+
+output "security_group_id" {
+  description = "ID of the security group"
+  value       = aws_security_group.test.id
+}

--- a/tests/test_data/module_without_provider/variables.tf
+++ b/tests/test_data/module_without_provider/variables.tf
@@ -1,0 +1,23 @@
+variable "instance" {
+  description = "Instance configuration"
+  type = object({
+    kind    = string
+    flavor  = string
+    version = string
+  })
+}
+
+variable "instance_name" {
+  description = "Instance name"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment"
+  type        = string
+}
+
+variable "inputs" {
+  description = "Inputs"
+  type        = object({})
+}


### PR DESCRIPTION
Fixes #62 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added validation to detect and prevent Terraform provider blocks in module files, enforcing that providers must be specified via configuration files instead.
  - Users now receive clear error messages if provider blocks are found, including filenames and guidance for correction.

- **Bug Fixes**
  - Improved error handling for unparseable Terraform files, issuing warnings without interrupting validation.

- **Tests**
  - Introduced comprehensive tests to verify provider block validation and error reporting in various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->