### PR TITLE
Add skip_output_write option to register_module and update output.facets.yaml handling

### DIFF
--- a/ftf_cli/commands/preview_module.py
+++ b/ftf_cli/commands/preview_module.py
@@ -13,7 +13,6 @@ import getpass
 import yaml
 import hcl2
 import json
-import hcl
 
 
 @click.command()

--- a/ftf_cli/commands/preview_module.py
+++ b/ftf_cli/commands/preview_module.py
@@ -90,9 +90,26 @@ def preview_module(
         return parsed
 
     def extract_output_structures(parsed_outputs):
-        locals_ = parsed_outputs.get("locals", [{}])[0]
-        output_interfaces = locals_.get("output_interfaces", [{}])[0]
-        output_attributes = locals_.get("output_attributes", [{}])[0]
+        locals_list = parsed_outputs.get("locals")
+        if isinstance(locals_list, list) and locals_list:
+            locals_ = locals_list[0]
+        elif isinstance(locals_list, dict):
+            locals_ = locals_list
+        else:
+            locals_ = {}
+
+        output_interfaces = locals_.get("output_interfaces", {})
+        if isinstance(output_interfaces, list) and output_interfaces:
+            output_interfaces = output_interfaces[0]
+        elif not isinstance(output_interfaces, dict):
+            output_interfaces = {}
+
+        output_attributes = locals_.get("output_attributes", {})
+        if isinstance(output_attributes, list) and output_attributes:
+            output_attributes = output_attributes[0]
+        elif not isinstance(output_attributes, dict):
+            output_attributes = {}
+
         return output_interfaces, output_attributes
 
     def write_output_lookup_tree(path, output_interfaces, output_attributes):

--- a/ftf_cli/commands/preview_module.py
+++ b/ftf_cli/commands/preview_module.py
@@ -219,7 +219,7 @@ def preview_module(
                 except Exception as e:
                     click.echo(f"Error generating output.facets.yaml: {e}")
             else:
-                click.echo(f"output.facets.yaml already exists, skipping generation.")
+                click.echo("output.facets.yaml already exists, skipping generation.")
 
         # Register the module
         register_module(

--- a/ftf_cli/commands/preview_module.py
+++ b/ftf_cli/commands/preview_module.py
@@ -66,7 +66,7 @@ from ftf_cli.operations import register_module, publish_module, ModuleOperationE
     default=False,
     callback=validate_boolean,
     is_flag=False,
-    help="Skip writing output.facets.yaml file and send skipOutputWrite in module metadata.",
+    help="Do not update the output type in facets. Set to true only if you have already registered the output type before calling this command.",
 )
 def preview_module(
     path,

--- a/ftf_cli/commands/preview_module.py
+++ b/ftf_cli/commands/preview_module.py
@@ -1,18 +1,18 @@
 import os
 import click
+import getpass
+import yaml
+import hcl2
+import json
 from ftf_cli.utils import (
     is_logged_in,
     validate_boolean,
     generate_output_lookup_tree,
     get_profile_with_priority,
+    generate_output_tree,
 )
 from ftf_cli.commands.validate_directory import validate_directory
 from ftf_cli.operations import register_module, publish_module, ModuleOperationError
-
-import getpass
-import yaml
-import hcl2
-import json
 
 
 @click.command()
@@ -85,7 +85,7 @@ def preview_module(
         output_file = os.path.join(path, "outputs.tf")
         if not os.path.exists(output_file):
             return None
-        with open(output_file, "r") as file:
+        with open(output_file, "r", encoding="utf-8") as file:
             parsed = hcl2.load(file)
         return parsed
 
@@ -104,20 +104,19 @@ def preview_module(
             }
         }
         transformed_output = generate_output_lookup_tree(output)
-        with open(output_json_path, "w") as file:
+        with open(output_json_path, "w", encoding="utf-8") as file:
             json.dump(transformed_output, file, indent=4)
         return output_json_path
 
     def write_output_facets_yaml(path, output_interfaces, output_attributes):
         output_facets_file = os.path.join(path, "output.facets.yaml")
-        from ftf_cli.utils import generate_output_tree
         interfaces_schema = generate_output_tree(output_interfaces)
         attributes_schema = generate_output_tree(output_attributes)
         out_schema = {
             "interfaces": interfaces_schema,
             "attributes": attributes_schema,
         }
-        with open(output_facets_file, "w") as f:
+        with open(output_facets_file, "w", encoding="utf-8") as f:
             yaml.dump({"out": out_schema}, f, sort_keys=False)
         return output_facets_file
 
@@ -149,7 +148,7 @@ def preview_module(
 
     # Load facets.yaml and modify if necessary
     yaml_file = os.path.join(path, "facets.yaml")
-    with open(yaml_file, "r") as file:
+    with open(yaml_file, "r", encoding="utf-8") as file:
         facets_data = yaml.safe_load(file)
 
     original_version = facets_data.get("version", "1.0")
@@ -167,11 +166,11 @@ def preview_module(
         click.echo(f"Sample version modified to: {new_sample_version}")
 
         # Write modified version back to facets.yaml
-        with open(yaml_file, "w") as file:
+        with open(yaml_file, "w", encoding="utf-8") as file:
             yaml.dump(facets_data, file, sort_keys=False)
 
     # Write the updated facets.yaml with validated files
-    with open(yaml_file, "w") as file:
+    with open(yaml_file, "w", encoding="utf-8") as file:
         yaml.dump(facets_data, file, sort_keys=False)
 
     control_plane_url = credentials["control_plane_url"]
@@ -244,7 +243,7 @@ def preview_module(
         if is_local_develop:
             facets_data["version"] = original_version
             facets_data["sample"]["version"] = original_sample_version
-            with open(yaml_file, "w") as file:
+            with open(yaml_file, "w", encoding="utf-8") as file:
                 yaml.dump(facets_data, file, sort_keys=False)
             click.echo(f"Version reverted to: {original_version}")
             click.echo(f"Sample version reverted to: {original_sample_version}")

--- a/ftf_cli/operations.py
+++ b/ftf_cli/operations.py
@@ -6,7 +6,6 @@ import base64
 from typing import Dict, Optional, Tuple
 import requests
 import click
-import io
 
 
 class ModuleOperationError(Exception):

--- a/ftf_cli/operations.py
+++ b/ftf_cli/operations.py
@@ -124,19 +124,20 @@ def register_module(
                 temp_metadata_fd, temp_metadata_path = tempfile.mkstemp(suffix=".json")
                 with os.fdopen(temp_metadata_fd, "wb") as temp_metadata_file:
                     temp_metadata_file.write(metadata_json)
-                metadata_file = open(temp_metadata_path, "rb")
-                files["metadata"] = (
-                    "metadata.json",
-                    metadata_file,
-                    "application/json",
-                )
-
-            # Make the request
-            response = requests.post(upload_url, headers=headers, files=files)
-
-            if 'metadata' in files:
-                metadata_file.close()
-                os.remove(temp_metadata_path)
+                try:
+                    with open(temp_metadata_path, "rb") as metadata_file:
+                        files["metadata"] = (
+                            "metadata.json",
+                            metadata_file,
+                            "application/json",
+                        )
+                        # Make the request
+                        response = requests.post(upload_url, headers=headers, files=files)
+                finally:
+                    os.remove(temp_metadata_path)
+            else:
+                # Make the request
+                response = requests.post(upload_url, headers=headers, files=files)
 
         # Check response
         if response.status_code == 200:

--- a/ftf_cli/operations.py
+++ b/ftf_cli/operations.py
@@ -6,6 +6,7 @@ import base64
 from typing import Dict, Optional, Tuple
 import requests
 import click
+import io
 
 
 class ModuleOperationError(Exception):
@@ -66,6 +67,7 @@ def register_module(
         git_ref: Optional[str] = None,
         is_feature_branch: bool = False,
         auto_create: bool = False,
+        skip_output_write: bool = False,
 ) -> None:
     """Register a module with the control plane"""
 
@@ -107,8 +109,8 @@ def register_module(
         with open(zip_path, "rb") as zip_file:
             files = {"file": ("module.zip", zip_file, "application/zip")}
 
-            # Prepare metadata if git info is provided
-            if any([git_url, git_ref, is_feature_branch, auto_create]):
+            # Prepare metadata if git info is provided or skip_output_write is set
+            if any([git_url, git_ref, is_feature_branch, auto_create, skip_output_write]):
                 metadata = {}
                 if git_url:
                     metadata["gitUrl"] = git_url
@@ -116,15 +118,25 @@ def register_module(
                     metadata["gitRef"] = git_ref
                 metadata["featureBranch"] = is_feature_branch
                 metadata["autoCreate"] = auto_create
+                metadata["skipOutputWrite"] = skip_output_write
 
+                metadata_json = json.dumps(metadata).encode()
+                temp_metadata_fd, temp_metadata_path = tempfile.mkstemp(suffix=".json")
+                with os.fdopen(temp_metadata_fd, "wb") as temp_metadata_file:
+                    temp_metadata_file.write(metadata_json)
+                metadata_file = open(temp_metadata_path, "rb")
                 files["metadata"] = (
                     "metadata.json",
-                    json.dumps(metadata),
+                    metadata_file,
                     "application/json",
                 )
 
             # Make the request
             response = requests.post(upload_url, headers=headers, files=files)
+
+            if 'metadata' in files:
+                metadata_file.close()
+                os.remove(temp_metadata_path)
 
         # Check response
         if response.status_code == 200:


### PR DESCRIPTION
- Introduced skip_output_write parameter in register_module to control output file generation.
- Enhanced preview_module to conditionally generate output.facets.yaml based on the new option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new CLI option to optionally skip generating the output facets YAML file during module preview.
  - Output facets YAML file is now generated only if it does not already exist.

- **Bug Fixes**
  - Ensured temporary output facets YAML files are properly cleaned up after use.

- **Tests**
  - Added tests to verify correct creation, skipping, and non-overwriting of the output facets YAML file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->