### PR TITLE
version is optional in providers

### DIFF
--- a/ftf_cli/schema.py
+++ b/ftf_cli/schema.py
@@ -38,7 +38,7 @@ yaml_schema = {
                                             "additionalProperties": True,
                                         },
                                     },
-                                    "required": ["source", "version", "attributes"],
+                                    "required": ["source", "attributes"],
                                 }
                             },
                         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Made the "version" property optional for providers in the outputs, allowing greater flexibility when specifying provider details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->