### PR TITLE
Set checkov to latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "Click",
     "Jinja2",
     "PyYAML",
-    "checkov",
+    "checkov>=3.2.457",
     "jsonschema",
     "requests",
     "questionary",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required version of the "checkov" dependency to 3.2.457 or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->