### PR TITLE
Name length limit to facets.yaml json schema

### DIFF
--- a/ftf_cli/schema.py
+++ b/ftf_cli/schema.py
@@ -104,6 +104,10 @@ yaml_schema = {
             },
             "additionalProperties": True
         },
+        "name_length_limit": {
+            "type": "integer",
+            "minimum": 1,
+        }
     },
     "required": ["intent", "flavor", "version", "description", "spec", "clouds"],
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional configuration field, name_length_limit, to control maximum allowed name length. Accepts an integer value of 1 or greater. If not provided, no length limit is enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->