### PR TITLE
Add followlinks parameter to zip creation

### DIFF
--- a/ftf_cli/operations.py
+++ b/ftf_cli/operations.py
@@ -43,7 +43,7 @@ def create_module_zip(path: str) -> str:
 
     try:
         with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
-            for root, dirs, files in os.walk(path):
+            for root, dirs, files in os.walk(path, followlinks=True):
                 for file in files:
                     file_path = os.path.join(root, file)
                     arcname = os.path.relpath(file_path, path)


### PR DESCRIPTION
## Summary
- Added `followlinks=True` parameter to `os.walk()` in the `create_module_zip` function
- This allows symbolic links to be followed when creating module zip files
- Existing exception handling already covers potential errors from following symlinks

## Test plan
- [ ] Test zip creation with directories containing symbolic links
- [ ] Verify that symbolic links are properly included in the generated zip files
- [ ] Ensure existing error handling works correctly with symlink scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)