### PR TITLE
Add multiple cloud support to generate-module command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ ftf generate-module [OPTIONS] /path/to/module
 **Options**:
 - `-i, --intent`: (prompt) The intent or purpose of the module.
 - `-f, --flavor`: (prompt) The flavor or variant of the module.
-- `-c, --cloud`: (prompt) Target cloud provider (e.g. aws, gcp, azure).
+- `-c, --cloud`: (prompt) Target cloud provider(s). Supports single (e.g. aws) or comma-separated multiple clouds (e.g. aws,gcp,azure).
 - `-t, --title`: (prompt) Human-readable title of the module.
 - `-d, --description`: (prompt) Description outlining module functionality.
 

--- a/ftf_cli/commands/generate_module.py
+++ b/ftf_cli/commands/generate_module.py
@@ -22,7 +22,24 @@ import importlib.resources as pkg_resources
     help="The version of the module. If not provided, the default version will be 1.0. and the module will increment the version number.",
 )
 def generate_module(path, intent, flavor, cloud, title, description, version):
-    """Generate a new module."""
+    """
+    Generate a new module by rendering built-in templates into a target directory.
+    
+    Parameters:
+        path (str): Destination base path where the module directory will be created.
+        intent (str): Intent name used to construct the module path and passed to templates.
+        flavor (str): Flavor name used to construct the module path and passed to templates.
+        cloud (str): Cloud identifier or comma-separated list of clouds (e.g., "aws" or "aws,azure").
+        title (str): Human-readable title passed into templates.
+        description (str): Description text passed into templates.
+        version (str): Version identifier appended to the module path; must not be a digits-only string.
+    
+    Raises:
+        click.UsageError: If `version` is digits-only, if the requested version already exists, or if version parsing fails when attempting to suggest an alternate version.
+    
+    Side effects:
+        Creates the module directory (including parent directories) and writes rendered template files into it.
+    """
     if str(version).isdigit():
         raise click.UsageError(
             f"❌ Version {version} is not a valid version. Use a valid version like 1.0"

--- a/ftf_cli/commands/generate_module.py
+++ b/ftf_cli/commands/generate_module.py
@@ -57,6 +57,9 @@ def generate_module(path, intent, flavor, cloud, title, description, version):
     templates_path = pkg_resources.files("ftf_cli.commands.templates")
     env = Environment(loader=FileSystemLoader(str(templates_path)))
 
+    # Parse cloud input: supports both single ("aws") and multiple ("aws,azure,gcp")
+    cloud_list = [c.strip() for c in cloud.split(',')]
+
     # Render and write templates
     for template_name in [
         "main.tf.j2",
@@ -69,6 +72,7 @@ def generate_module(path, intent, flavor, cloud, title, description, version):
             intent=intent,
             flavor=flavor,
             cloud=cloud,
+            clouds=cloud_list,
             title=title,
             description=description,
         )

--- a/ftf_cli/commands/templates/facets.yaml.j2
+++ b/ftf_cli/commands/templates/facets.yaml.j2
@@ -1,7 +1,7 @@
 intent: {{ intent }}
 flavor: {{ flavor }}
 version: "1.0"
-clouds: [ {{ cloud }} ]
+clouds: {{ clouds }}
 description: {{ description }}
 spec:
   title: {{ title }}


### PR DESCRIPTION
## Summary
Enable `generate-module` command to accept multiple clouds with full backward compatibility. Users can now specify either a single cloud or comma-separated multiple clouds.

## Changes Made
- ✅ Parse comma-separated cloud input into list in `generate_module.py`
- ✅ Update `facets.yaml.j2` template to render clouds as proper YAML array
- ✅ Update README.md documentation with multiple cloud examples

## Examples

### Single cloud (backward compatible):
```bash
ftf generate-module -c aws
# Results in: clouds: ['aws']
```

### Multiple clouds (new feature):
```bash
ftf generate-module -c aws,gcp,azure
# Results in: clouds: ['aws', 'gcp', 'azure']
```

### With spaces (automatically stripped):
```bash
ftf generate-module -c "aws, gcp , azure"
# Results in: clouds: ['aws', 'gcp', 'azure']
```

## Testing
All test cases verified:
- ✅ Single cloud input works
- ✅ Multiple comma-separated clouds work
- ✅ Whitespace around commas is stripped correctly
- ✅ Backward compatibility maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the -c/--cloud CLI help to show multiple clouds can be specified as comma-separated values (e.g., aws,gcp,azure).

* **New Features**
  * Generate Module now accepts and processes multiple cloud providers in one command, producing module output that reflects the specified multi-cloud configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->